### PR TITLE
Request header patching

### DIFF
--- a/hammertime/engine/aiohttp.py
+++ b/hammertime/engine/aiohttp.py
@@ -62,8 +62,14 @@ class AioHttpEngine:
 
         timeout_value = entry.arguments.get("timeout", self.timeout)
         with timeout(timeout_value + 0.3, loop=self.loop):
-            response = await self.session.request(method=req.method, url=req.url, proxy=self.proxy,
-                                                  timeout=timeout_value)
+            extra_args = {}
+            if self.proxy:
+                extra_args["proxy"] = self.proxy
+            if entry.request.headers:
+                extra_args["headers"] = entry.request.headers
+
+            response = await self.session.request(method=req.method, url=req.url,
+                                                  timeout=timeout_value, **extra_args)
 
         # When the request is simply rejected, we want to keep the persistent connection alive
         async with ProtectedSession(response, RejectRequest):

--- a/hammertime/http.py
+++ b/hammertime/http.py
@@ -27,9 +27,10 @@ Entry.create = lambda *args, response=None, arguments=None, **kwargs: Entry(requ
 
 class Request:
 
-    def __init__(self, url, *, method='GET'):
+    def __init__(self, url, *, method='GET', headers=None):
         self.method = method
         self.url = url
+        self.headers = headers or {}
 
     def __hash__(self):
         return hash(self.__dict__)

--- a/hammertime/rules/header.py
+++ b/hammertime/rules/header.py
@@ -15,16 +15,12 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from .body import IgnoreLargeBody
-from .header import SetHeader
-from .status import RejectStatusCode, DetectSoft404
-from .timeout import DynamicTimeout
 
+class SetHeader:
 
-__all__ = [
-    DetectSoft404,
-    DynamicTimeout,
-    IgnoreLargeBody,
-    RejectStatusCode,
-    SetHeader,
-]
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    async def before_request(self, entry):
+        entry.request.headers[self.name] = self.value

--- a/tests/aiohttp_test.py
+++ b/tests/aiohttp_test.py
@@ -16,7 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, ANY
 from fixtures import async_test
 
 from hammertime.engine.aiohttp import AioHttpEngine
@@ -75,6 +75,19 @@ class TestAioHttpEngine(TestCase):
 
         engine.session.request.assert_called_once_with(method=entry.request.method, url="http://www.example.com/1",
                                                        timeout=10, proxy="http://some.proxy.com/")
+
+    @async_test()
+    async def test_specify_header(self, loop):
+        asyncio.set_event_loop(loop)
+        engine = AioHttpEngine(loop=loop)
+        engine.session.request = make_mocked_coro(return_value=FakeResponse())
+        entry = Entry.create("http://www.example.com/1", headers={"User-Agent": "Hammertime 1.2.3"})
+
+        await engine.perform(entry, Heuristics())
+
+        engine.session.request.assert_called_once_with(method=entry.request.method, url="http://www.example.com/1",
+                                                       timeout=ANY,
+                                                       headers={"User-Agent": "Hammertime 1.2.3"})
 
 
 class FakeResponse:

--- a/tests/set_header_test.py
+++ b/tests/set_header_test.py
@@ -15,16 +15,19 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from .body import IgnoreLargeBody
-from .header import SetHeader
-from .status import RejectStatusCode, DetectSoft404
-from .timeout import DynamicTimeout
+import unittest
+from fixtures import async_test
+
+from hammertime.http import Entry
+from hammertime.rules.header import SetHeader
 
 
-__all__ = [
-    DetectSoft404,
-    DynamicTimeout,
-    IgnoreLargeBody,
-    RejectStatusCode,
-    SetHeader,
-]
+class SetHeaderTest(unittest.TestCase):
+
+    @async_test()
+    async def test_set_header(self):
+        rule = SetHeader("User-Agent", "HammerTime 1.2")
+        entry = Entry.create("http://example.coM")
+        await rule.before_request(entry)
+
+        self.assertEqual("HammerTime 1.2", entry.request.headers["User-Agent"])

--- a/tests/set_header_test.py
+++ b/tests/set_header_test.py
@@ -27,7 +27,7 @@ class SetHeaderTest(unittest.TestCase):
     @async_test()
     async def test_set_header(self):
         rule = SetHeader("User-Agent", "HammerTime 1.2")
-        entry = Entry.create("http://example.coM")
+        entry = Entry.create("http://example.com")
         await rule.before_request(entry)
 
         self.assertEqual("HammerTime 1.2", entry.request.headers["User-Agent"])


### PR DESCRIPTION
Allow request header patching, either for setting simple values like user agent or access tokens.