### PR TITLE
Improve interface consistency

### DIFF
--- a/hammertime/core.py
+++ b/hammertime/core.py
@@ -59,7 +59,11 @@ class HammerTime:
 
     def request(self, *args, **kwargs):
         if self.is_closed:
-            raise asyncio.CancelledError()
+            # Return an exception as if it were a task when attempting to request on a closed engine
+            future = asyncio.Future(loop=self.loop)
+            future.set_exception(asyncio.CancelledError())
+            return future
+
         self.stats.requested += 1
         task = self.loop.create_task(self._request(*args, **kwargs))
         self.tasks.append(task)

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -207,7 +207,7 @@ class InitTest(TestCase):
 
         self.assertTrue(hammertime.is_closed)
         with self.assertRaises(asyncio.CancelledError):
-            hammertime.request("http://example.com")
+            await hammertime.request("http://example.com")
 
     @async_test()
     async def test_interrupt_close_hammertime(self, loop):


### PR DESCRIPTION
Moving the exception raising to a future so all cases return a task-like object.