### PR TITLE
Optional success iterator

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,6 +28,8 @@ reject_5xx = RejectStatusCode(range(500, 600))
 timeout = DynamicTimeout(min_timeout=0.01, max_timeout=1, retries=3)
 hammertime.heuristics.add_multiple([reject_5xx, timeout])
 
+hammertime.collect_successful_requests()
+
 async def fetch():
     for i in range(10000):
         hammertime.request("http://example.com/")

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -65,7 +65,11 @@ Return an AsyncIterator with the entries of all successful requests. No exceptio
 requests that caused an exception are not returned. Entries are returned as soon as they are available, thus the
 entries are not in the same order as the requests.
 
-Return: An AsyncIterator containing [HTTP entries](#entry) of the successful requests.
+*Since 0.2.0* In order to be functional, *collect_successful_requests* must be called prior to requests being
+performed.
+
+Return: An AsyncIterator containing [HTTP entries](#entry) of the successful requests. Intended to be used with 
+*async for*.
 
 **coroutine close()**
 

--- a/hammertime/core.py
+++ b/hammertime/core.py
@@ -40,10 +40,10 @@ class HammerTime:
             self.request_engine.set_proxy(proxy)
         self.heuristics = Heuristics(kb=kb, request_engine=self.request_engine)
 
-        self.completed_queue = asyncio.Queue(loop=self.loop)
         self.tasks = deque()
         self.closed = asyncio.Future(loop=loop)
         self.loop.add_signal_handler(signal.SIGINT, self._interrupt)
+        self._success_iterator = None
 
     @property
     def completed_count(self):
@@ -74,7 +74,7 @@ class HammerTime:
         try:
             entry = Entry.create(*args, **kwargs)
             entry = await self.request_engine.perform(entry, heuristics=self.heuristics)
-            await self.completed_queue.put(entry)
+
             return entry
         except (HammerTimeException, asyncio.CancelledError):
             raise
@@ -83,16 +83,23 @@ class HammerTime:
         finally:
             self.stats.completed += 1
 
+    def collect_successful_requests(self):
+        assert self._success_iterator is None, "Can only be called once."
+        self._success_iterator = QueueIterator(loop=self.loop, has_pending_cb=lambda: len(self.tasks) > 0)
+
     def successful_requests(self):
-        if len(self.tasks) == 0 and self.completed_queue.qsize() == 0:
-            self.completed_queue.put_nowait(None)
-        return QueueIterator(self.completed_queue)
+        assert self._success_iterator is not None, "You must enable success collection prior to performing requests."
+        return self._success_iterator
 
     def _on_completion(self, task):
         self._drain(task)
         self.tasks.remove(task)
-        if len(self.tasks) == 0:
-            self.completed_queue.put_nowait(None)
+
+        if self._success_iterator:
+            # Checking exception conditions explicitly to avoid using try/except blocks
+            entry = task.result() if not task.cancelled() and not task.exception() else None
+
+            self._success_iterator.complete(entry)
 
     def _drain(self, task):
         try:
@@ -123,8 +130,13 @@ class HammerTime:
 
 class QueueIterator:
 
-    def __init__(self, queue):
-        self.queue = queue
+    def __init__(self, *, loop, has_pending_cb):
+        self.queue = asyncio.Queue(loop=loop)
+        self.has_pending = has_pending_cb
+
+    def complete(self, entry):
+        if entry or not self.has_pending():
+            self.queue.put_nowait(entry)
 
     async def __aiter__(self):
         return self
@@ -134,7 +146,7 @@ class QueueIterator:
             out = None
             if not self.queue.empty():
                 out = self.queue.get_nowait()
-            else:
+            elif self.has_pending():
                 out = await self.queue.get()
 
             if out is None:

--- a/hammertime/core.py
+++ b/hammertime/core.py
@@ -84,11 +84,12 @@ class HammerTime:
             self.stats.completed += 1
 
     def collect_successful_requests(self):
-        assert self._success_iterator is None, "Can only be called once."
+        assert self._success_iterator is None, "collect_successful_requests() can only be called once."
         self._success_iterator = QueueIterator(loop=self.loop, has_pending_cb=lambda: len(self.tasks) > 0)
 
     def successful_requests(self):
-        assert self._success_iterator is not None, "You must enable success collection prior to performing requests."
+        assert self._success_iterator is not None, \
+               "You must call collect_successful_requests() prior to performing requests."
         return self._success_iterator
 
     def _on_completion(self, task):

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -70,6 +70,7 @@ class InitTest(TestCase):
     @async_test()
     async def test_loop_over_results(self, loop):
         h = HammerTime(loop=loop, request_engine=FakeEngine())
+        h.collect_successful_requests()
         h.request("http://example.com/1")
         h.request("http://example.com/2")
 
@@ -84,6 +85,7 @@ class InitTest(TestCase):
     @async_test()
     async def test_successive_loop_over_results(self, loop):
         h = HammerTime(loop=loop, request_engine=FakeEngine())
+        h.collect_successful_requests()
         h.request("http://example.com/1")
         h.request("http://example.com/2")
         out = set()
@@ -105,6 +107,7 @@ class InitTest(TestCase):
     async def test_skip_results_that_fail(self, loop):
         h = HammerTime(loop=loop, request_engine=FakeEngine())
         h.heuristics.add(BlockRequest("http://example.com/1"))
+        h.collect_successful_requests()
         h.request("http://example.com/1")
         h.request("http://example.com/2")
 
@@ -119,11 +122,12 @@ class InitTest(TestCase):
     @async_test()
     async def test_successful_requests_return_if_no_pending_requests(self, loop):
         h = HammerTime(loop=loop, request_engine=FakeEngine())
+        h.collect_successful_requests()
 
         try:
             with async_timeout.timeout(0.001):
                 async for entry in h.successful_requests():
-                    pass
+                    entry.request
         except asyncio.TimeoutError:
             self.fail("Function blocked.")
 
@@ -189,6 +193,7 @@ class InitTest(TestCase):
         engine = MagicMock()
         engine.perform = make_mocked_coro(raise_exception=asyncio.CancelledError)
         hammertime = HammerTime(loop=loop, request_engine=engine)
+        hammertime.collect_successful_requests()
 
         for i in range(5):
             hammertime.request("http://example.com")


### PR DESCRIPTION
Required in order to avoid linear memory increase for use cases not using successful_requests(). Requires that the feature be explicitly enabled.

Some re-factoring was performed to limit the amount of code touching the feature.