### PR TITLE
Using a forked version of simhash-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='HammerTime-http',
       extras_require={
           'simhash':  ['simhash==2.0.0'],
           'simhash-py': [
-              'simhash-py@git+https://github.com/seomoz/simhash-py.git@46de27b310022e3ac7a856c5fc4f4b0df1d76af7',
+              'forkedsimhash-py==0.4.2',
               'six'
           ]
       },


### PR DESCRIPTION
The original version doesn't do pypi releases anymore.